### PR TITLE
added docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM nerfstudio/nerfstudio
+
+WORKDIR /workspace/
+
+USER root
+
+# Install git
+RUN apt-get update && apt-get install -y git
+
+# Install pixi
+RUN curl -fsSL https://pixi.sh/install.sh | bash
+
+# Add pixi to PATH
+ENV PATH="/root/.pixi/bin:${PATH}"
+
+# Clone the repository and run the application
+COPY . /workspace/InstantSplat
+
+WORKDIR /workspace/InstantSplat
+
+EXPOSE 7860
+
+RUN pixi install 
+
+CMD ["pixi", "run", "--environment", "default", "app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.7'
+
+services:
+
+  instant-splat:
+    build: 
+      context: .
+      dockerfile: ./Dockerfile
+    stdin_open: true
+    tty: true
+    networks:
+      - main
+    restart: always
+    ports:
+      - "7860:7860"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: 'nvidia'
+              count: all
+              capabilities: [gpu]
+
+networks:
+  main:
+    driver: bridge

--- a/tools/gradio_app.py
+++ b/tools/gradio_app.py
@@ -26,4 +26,4 @@ with gr.Blocks() as demo:
         multi_img_block.render()
 
 if __name__ == "__main__":
-    demo.launch()
+    demo.launch(server_name="0.0.0.0")


### PR DESCRIPTION
added docker-compose & Dockerfile so users can now run InstantSplat by simply running `docker-compose up`

had to define the gradio app's server name to be `'0.0.0.0'` so the app can be exposed & accessed through the docker container